### PR TITLE
Don't kill browser process after stopping server.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,12 @@ Authors
 Changelog
 =========
 
+Version 1.1.2 (unreleased)
+-------------------------
+* Don't kill browser after stopping server.
+  (Removed psutil as requirements)
+* Added option to use Geiss and Redis server.
+
 Version 1.1.1 (2017-01-26)
 -------------------------
 * Updated README to Python 3.5.

--- a/openslides_gui/gui.py
+++ b/openslides_gui/gui.py
@@ -6,11 +6,10 @@ import json
 import locale
 import os
 import queue
+import signal
 import subprocess
 import sys
 import threading
-
-import psutil
 
 import wx
 import wx.adv
@@ -106,13 +105,8 @@ class RunCommandControl(wx.Panel):
             return
 
         self.te_output.AppendText(_("Stopping server..."))
-        # hard-kill the spawned process tree
-        # TODO: offer the server the chance for a clean shutdown
-        proc = psutil.Process(self.child_process.pid)
-        kill_procs = [proc]
-        kill_procs.extend(proc.children(recursive=True))
-        for p in kill_procs:
-            p.kill()
+        # kill the main process (without killing browser)
+        os.kill(self.child_process.pid, signal.SIGINT)
 
     def on_update_timer(self, evt):
         is_alive = self.is_alive()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@
 
 openslides>=2.0
 wxPython-Phoenix>=3.0.3.dev2562+33fadd8
-psutil>=4.3.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     install_requires=[
         "openslides",
         "wxPython-Phoenix",
-        "psutil",
     ],
     package_data={
         "openslides_gui": [


### PR DESCRIPTION
Use os.kill with SIGING instead of kill hard all subprocesses.
Fixed https://github.com/OpenSlides/OpenSlides/issues/3045